### PR TITLE
Fix issue with multiple checkouts

### DIFF
--- a/src/ReportGenerator.AzureBlobHistoryStorage/GitRepositoryAccessor.cs
+++ b/src/ReportGenerator.AzureBlobHistoryStorage/GitRepositoryAccessor.cs
@@ -49,6 +49,7 @@ public class GitRepositoryAccessor : IGitRepositoryAccessor
             .WithArguments(
                 $"config --local --add safe.directory {Utils.NormalizePathForGitSafeDirectory(_workingDirectory)}")
             .WithValidation(CommandResultValidation.ZeroExitCode)
+            .WithWorkingDirectory(_workingDirectory)
             .ExecuteAsync();
 
         await Cli.Wrap("git")


### PR DESCRIPTION
The change to add the git directory to the safe directory list doesn't work for multiple checkouts, since it's executed in the sources directory, which is not part of git.

For multiple checkouts (in Azure) you have the sources directory, which contains directories for all the checkouts that you do. So you need to execute the git commands in the earlier added Workdirectory (see PR #1 ).
